### PR TITLE
Added words.dg to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include demorphy/data/words.dg


### PR DESCRIPTION
> When I install DEMorphy the file words.dg is missing.

Thanks for the PR, this file is too big for a Python package hence I host it in the repo separately. Please follow the instructions, download from the repo directly and place it to its directory :wink: 